### PR TITLE
Add default model support via .env and remove deprecated file operation tools from coding agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,156 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# IDE specific files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS specific files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Azure specific
+.azure/
+
+# AI Agents Workshop specific
+*.log
+.env.*
+!.env.example
+secrets/
+keys/
+credentials/

--- a/1-toy-example/coding_agent.py
+++ b/1-toy-example/coding_agent.py
@@ -29,6 +29,9 @@ from composio_openai import ComposioToolSet, Action
 # Setup OpenAI client
 client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 
+# Honor the default model from environment variable or use gpt-4
+DEFAULT_MODEL = os.getenv("DEFAULT_MODEL", "gpt-4")
+
 # Setup Composio toolset for file operations
 composio_toolset = ComposioToolSet()
 
@@ -96,9 +99,7 @@ def create_coding_agent():
     file_tools = composio_toolset.get_tools(actions=[
         Action.FILETOOL_CREATE_FILE,
         Action.FILETOOL_EDIT_FILE,
-        Action.FILETOOL_READ_FILE,
         Action.FILETOOL_LIST_FILES,
-        Action.FILETOOL_DELETE_FILE,
     ])
     
     # Define the Python REPL tool
@@ -140,7 +141,7 @@ Always explain what you're doing and why, and make sure to test your code thorou
 """
     
     return {
-        "model": "gpt-4",
+        "model": DEFAULT_MODEL,
         "tools": [python_repl_tool] + file_tools,
         "system_instructions": system_instructions
     }


### PR DESCRIPTION
Adding support for a default model via an environment variable and reducing the number of file operation tools used in the coding agent. since those remove actions are NOT AVAILABLE.

Changes:
* Updated the `create_coding_agent` function to use the `DEFAULT_MODEL` variable instead of hardcoding "gpt-4" as the model. 
* Removed `Action.FILETOOL_READ_FILE` and `Action.FILETOOL_DELETE_FILE` from the list of file operation tools in the `create_coding_agent` function

fixes #2 